### PR TITLE
Extended the package file list to include the TTF

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "microns",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "The universal icon set for user interfaces.",
   "browser": "css/microns.css",
   "homepage": "https://www.s-ings.com/projects/microns-icon-font/",
@@ -11,6 +11,7 @@
     "fonts/microns.css",
     "fonts/microns.svg",
     "fonts/microns.eot",
+    "fonts/microns.ttf",
     "fonts/microns.woff",
     "fonts/microns.woff2",
     "fonts/microns.html",


### PR DESCRIPTION
### Summary ###

The package was publishing all our fonts except the ttf. It had microns.woff, microns.woff2, mirons.eot, microns.svg, but it was missing microns.ttf. This change set add it to the package file list.

It also bumps the version number to v1.0.6, but it'll need the admin to publish that fix to npm.

Resolves #3.