### PR TITLE
fixed wrong codepoint (also wrong on website)

### DIFF
--- a/icons.json
+++ b/icons.json
@@ -86,7 +86,7 @@
   {
     "name": "External",
     "class": "mu-external",
-    "code": "E70C",
+    "code": "E773",
     "match": "box|arrow|link|out"
   },
   {


### PR DESCRIPTION
The codepoint for mu-external is wrong. It is 773 instead of 70C. This is wrong also on the official website at https://www.s-ings.com/projects/microns-icon-font/